### PR TITLE
Add Queue size to check

### DIFF
--- a/check_pdns/check_pdns.py
+++ b/check_pdns/check_pdns.py
@@ -31,7 +31,7 @@ class PowerDNSStats:
     __warning = False
     __critical = False
     __store_path = '/tmp/check_pdns'
-    __values = ['packetcache-hit', 'packetcache-miss', 'query-cache-hit', 'query-cache-miss', 'recursing-answers', 'recursing-questions', 'corrupt-packets', 'servfail-packets', 'timedout-packets', 'udp-queries', 'tcp-queries']
+    __values = ['packetcache-hit', 'packetcache-miss', 'query-cache-hit', 'query-cache-miss', 'recursing-answers', 'recursing-questions', 'corrupt-packets', 'servfail-packets', 'timedout-packets', 'udp-queries', 'tcp-queries', 'qsize-q']
     __data = dict()
 
     def __init__(self, warning=False, critical=False, warningerr=False, criticalerr=False):


### PR DESCRIPTION
I suggest to add the `qsize-q` value to the default check. This value shows the powerdns queue to the backend and can indicate a problem with a slow backend or very high queries / attack.